### PR TITLE
feat: add support for pkl files

### DIFF
--- a/cmd/validator/validator.go
+++ b/cmd/validator/validator.go
@@ -2,7 +2,7 @@
 Validator recursively scans a directory to search for configuration files and
 validates them using the go package for each configuration type.
 
-Currently Apple PList XML, PKL, CSV, HCL, HOCON, INI, JSON, Properties, TOML, XML, and YAML.
+Currently Apple PList XML, CSV, HCL, HOCON, INI, JSON, PKL, Properties, TOML, XML, and YAML.
 configuration file types are supported.
 
 Usage: validator [OPTIONS] [<search_path>...]

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Boeing/config-file-validator/pkg/finder"
 	"github.com/Boeing/config-file-validator/pkg/reporter"
+	"github.com/Boeing/config-file-validator/pkg/validator"
 )
 
 func Test_CLI(t *testing.T) {
@@ -123,12 +124,11 @@ func Test_CLIRepoertErr(t *testing.T) {
 }
 
 func Test_CLI_IgnoreBadPklFileWhenBinaryNotFound(t *testing.T) {
-	// Save the original function before mocking and restore it after the test
-	originalIsPklBinaryPresent := isPklBinaryPresent
-	isPklBinaryPresent = func() bool {
+	// Override the binary checker for this test and restore it afterward
+	previousChecker := validator.SetPklBinaryChecker(func() bool {
 		return false
-	}
-	defer func() { isPklBinaryPresent = originalIsPklBinaryPresent }()
+	})
+	defer validator.SetPklBinaryChecker(previousChecker)
 
 	searchPath := "../../test/fixtures/subdir2/bad.pkl"
 	fsFinder := finder.FileSystemFinderInit(

--- a/pkg/validator/pkl.go
+++ b/pkg/validator/pkl.go
@@ -2,17 +2,51 @@ package validator
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os/exec"
+	"sync"
 
 	"github.com/apple/pkl-go/pkl"
 )
+
+var (
+	// ErrSkipped is returned when a validation is skipped due to a missing dependency.
+	ErrSkipped = errors.New("validation skipped")
+
+	isPklBinaryPresent = func() bool {
+		_, err := exec.LookPath("pkl")
+		return err == nil
+	}
+	// mutex for thread-safe modification of the checker function
+	mu sync.Mutex
+)
+
+// SetPklBinaryChecker allows overriding the default pkl binary check for testing.
+// It returns the previous checker function so it can be restored later.
+func SetPklBinaryChecker(checker func() bool) func() bool {
+	mu.Lock()
+	defer mu.Unlock()
+	previous := isPklBinaryPresent
+	isPklBinaryPresent = checker
+	return previous
+}
 
 // PklValidator is used to validate a byte slice that is intended to represent a
 // PKL file.
 type PklValidator struct{}
 
 // Validate attempts to evaluate the provided byte slice as a PKL file.
+// If the 'pkl' binary is not found, it returns ErrSkipped.
 func (PklValidator) Validate(b []byte) (bool, error) {
+	mu.Lock()
+	checker := isPklBinaryPresent
+	mu.Unlock()
+
+	if !checker() {
+		return false, ErrSkipped
+	}
+
 	ctx := context.Background()
 
 	// Convert the byte slice to a ModuleSource using TextSource

--- a/test/fixtures/good.pkl
+++ b/test/fixtures/good.pkl
@@ -1,7 +1,50 @@
-name = "Swallow"
+amends "pkl:Project"
 
-job {
-  title = "Sr. Nest Maker"
-  company = "Nests R Us"
-  yearsOfExperience = 2
+name = "PhoenixWebApp"
+
+package {
+  name = "phoenix"
+  version = "2.1.0"
+  authors = ["Phoenix Engineering <contact@phoenix.example>"]
 }
+
+database {
+  host = "db.phoenix.internal"
+  port = 5432
+  username = "phoenix_user"
+  poolSize = 20
+  sslMode = "require"
+}
+
+server {
+  host = "0.0.0.0"
+  port = 8080
+  logLevel = "info" // "debug", "info", "warn", "error"
+  corsOrigins = List("https://phoenix.example", "https://app.phoenix.example")
+}
+
+features {
+  newSignupFlow = true
+  apiRateLimiting = true
+  dashboardAnalytics = false
+}
+
+// --- Service Replica Configuration ---
+class Replica {
+  region: "us-east-1" | "us-west-2" | "eu-central-1"
+  instanceType: String
+  count: Int
+}
+
+replicas: List<Replica> = List(
+  new {
+    region = "us-east-1"
+    instanceType = "t3.medium"
+    count = 3
+  },
+  new {
+    region = "us-west-2"
+    instanceType = "t3.medium"
+    count = 2
+  }
+)


### PR DESCRIPTION
Closes #141

Addresses following comments left on the original (abandoned) PR here https://github.com/Boeing/config-file-validator/pull/164

- Moves PKL binary validation to the pkl validator
- Ensures we don't run into race conditions during testing by using a mutex lock
- Adds a more complete example for good.pkl
- Alphabetises list of supported config filetypes